### PR TITLE
A default loader to load config from `src/config` as default else use defined path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ npm install nestjs-config --save
 
 ### Getting Started
 
-Let's imagine that we have a folder called `config` in our project under `app/config`
+Let's imagine that we have a folder called `config` in our project under `src`
 
 ```bash
 
-/app
+/src
 ├── app.module.ts
 ├── config
 │   ├── express.ts
@@ -49,9 +49,7 @@ import { ConfigModule } from "nestjs-config";
 
 @Module({
     imports: [
-        ConfigModule.load( 
-            path.resolve(__dirname, 'config/**/*.{ts,js}')
-        ),
+        ConfigModule.load(),
     ],
 })
 export class AppModule {
@@ -62,6 +60,24 @@ We provide as first argument the glob of our interested configuration that we wa
 
 That's it!
 
+Now let's say that your application isn't in a folder called `src`, it's in `./app`.
+
+```ts
+import * as path from 'path';
+import { Module } from '@nestjs/common';
+import { ConfigModule } from "nestjs-config";
+
+@Module({
+    imports: [
+        ConfigModule.load(
+            path.resolve(__dirname, 'config/**/*.{ts,js}')
+        ),
+    ],
+})
+export class AppModule {
+
+}
+```
 
 ### Environment configuration
 

--- a/src/__tests__/config.module.spec.ts
+++ b/src/__tests__/config.module.spec.ts
@@ -15,4 +15,14 @@ describe('Config Nest Module', () => {
     expect(configService.get('config.server')).toBeTruthy();
     expect(configService.get('config.stub')).toBeTruthy();
   });
+
+  it('Will boot without glob', async () => {
+    const module = await Test.createTestingModule({
+      imports: [ConfigModule.load()],
+    }).compile();
+
+    const configService = module.get<ConfigService>(ConfigService);
+
+    expect(configService).toBeInstanceOf(ConfigService);
+  });
 });

--- a/src/module/config.module.ts
+++ b/src/module/config.module.ts
@@ -11,11 +11,11 @@ export class ConfigModule {
    * @param {DotenvOptions} options
    * @returns {DynamicModule}
    */
-  static load(glob: string, options?: DotenvOptions): DynamicModule {
+  static load(pattern?: string, options?: DotenvOptions): DynamicModule {
     const configProvider = {
       provide: ConfigService,
       useFactory: async (): Promise<any> => {
-        return ConfigService.load(glob, options);
+        return ConfigService.load(pattern, options);
       },
     };
     return {

--- a/src/module/config.module.ts
+++ b/src/module/config.module.ts
@@ -11,11 +11,11 @@ export class ConfigModule {
    * @param {DotenvOptions} options
    * @returns {DynamicModule}
    */
-  static load(pattern?: string, options?: DotenvOptions): DynamicModule {
+  static load(glob?: string, options?: DotenvOptions): DynamicModule {
     const configProvider = {
       provide: ConfigService,
       useFactory: async (): Promise<any> => {
-        return ConfigService.load(pattern, options);
+        return ConfigService.load(glob, options);
       },
     };
     return {

--- a/src/module/config.service.ts
+++ b/src/module/config.service.ts
@@ -42,10 +42,13 @@ export class ConfigService {
    * @returns {Promise<any>}
    */
   static async load(
-    glob: string,
+    glob?: string,
     options?: DotenvOptions | false,
   ): Promise<ConfigService> {
-    const configs = await this.loadConfigAsync(glob, options);
+    const configs = await this.loadConfigAsync(
+      typeof glob === 'undefined' ? this.src('config/**/*.{ts,js}') : glob,
+      options,
+    );
     return new ConfigService(configs);
   }
 


### PR DESCRIPTION
Not 100% on the README. 