### PR TITLE
fix: using dynamic path separator instead of file system's one

### DIFF
--- a/src/module/config.service.ts
+++ b/src/module/config.service.ts
@@ -255,11 +255,9 @@ export class ConfigService {
    * @returns {string}
    */
   protected static getConfigName(file: string) {
-    // Workaround: Glob is replacing '\' by '/' on Windows
-    // If it contains the file system's path separator, then that's it, or we get the opposite one.
-    const fileSeparator = file.indexOf(path.sep) >= 0 ? path.sep : path.sep === '/' ? '/' : '\\';
+    // Workaround: Glob is replacing '\' by '/' on Windows, so only use posix separator
     return file
-      .split(fileSeparator)
+      .split(path.posix.sep)
       .pop()
       .replace('.js', '')
       .replace('.ts', '');

--- a/src/module/config.service.ts
+++ b/src/module/config.service.ts
@@ -255,8 +255,11 @@ export class ConfigService {
    * @returns {string}
    */
   protected static getConfigName(file: string) {
+    // Workaround: Glob is replacing '\' by '/' on Windows
+    // If it contains the file system's path separator, then that's it, or we get the opposite one.
+    const fileSeparator = file.indexOf(path.sep) >= 0 ? path.sep : path.sep === '/' ? '/' : '\\';
     return file
-      .split(path.sep)
+      .split(fileSeparator)
       .pop()
       .replace('.js', '')
       .replace('.ts', '');


### PR DESCRIPTION
@see [issue#28](https://github.com/nestjs-community/nestjs-config/issues/28) for original explanation.

[Node-glob](https://github.com/isaacs/node-glob) package **is replacing backslashes by forward slashes** on Windows (@see [this commit](https://github.com/isaacs/node-glob/commit/b2aa29bc066de1593d78864158e6a1adafd06e3c#diff-d7716810d825f4b55d18727c3ccb24e6)).
As _Nestjs-config_ uses `path.sep` to infer the path separator used, we try to split the path using backslashes whereas the paths contains only simple slashes.

Here is a workaround to guess **which separator is used dynamically**. It is certainly not as elegant as using `path.sep` only but I think we'd have to wait for a while before [issue#173](https://github.com/isaacs/node-glob/issues/173) of Node-glob is treated...

_I'm opened to any suggestions as this is my very first pull-request ;-)_