### PR TITLE
Improve param decorators

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,8 +267,8 @@ export default class UserController {
     
     @Get("/")
     @Configurable()
-    index(@ConfigParam('my.parameter', 'deafult value') parameter) {
-        return parameter;
+    index(@ConfigParam('my.parameter', 'deafult value') parameter?: string) {
+        return { data: parameter };
     }
 }
 ```
@@ -284,8 +284,8 @@ export default class UserController {
     @Configurable()
     @Get("/")   // <-- nestjs decorator won't work because it placed after @Configurable()
     @UseInterceptors(TransformInterceptor)// <-- nestjs decorator won't work because it placed after @Configurable()
-    index(@ConfigParam('my.parameter', 'deafult value') parameter) {
-        return parameter;
+    index(@ConfigParam('my.parameter', 'deafult value') parameter?: string) {
+        return { data: parameter };
     }
 }
 ```
@@ -303,8 +303,8 @@ export default class UserController {
     @Get("/") // <-- nestjs decorator will work fine because it placed after @Configurable()
     @Configurable()
     @UseInterceptors(TransformInterceptor) // <-- nestjs decorator won't work because it placed after @Configurable()
-    index(@ConfigParam('my.parameter', 'deafult value') parameter) {
-        return parameter;
+    index(@ConfigParam('my.parameter', 'deafult value') parameter?: string) {
+        return { data: parameter };
     }
 }
 ```

--- a/examples/decorators/user.controller.ts
+++ b/examples/decorators/user.controller.ts
@@ -3,8 +3,8 @@ import { ConfigParam, Configurable } from 'nestjs-config';
 
 @Controller('user')
 export default class UserController {
-  @Configurable()
   @Get('')
+  @Configurable()
   index(
     @ConfigParam('user.name', 'test')
     username,

--- a/src/__tests__/config.module.spec.ts
+++ b/src/__tests__/config.module.spec.ts
@@ -34,7 +34,7 @@ describe('Config Nest Module', () => {
       constructor() {}
 
       @Configurable()
-      testConfig(@ConfigParam('config.server') configKey: string) {
+      testConfig(@ConfigParam('config.server') configKey?: { port: number }) {
         return configKey;
       }
     }
@@ -46,7 +46,7 @@ describe('Config Nest Module', () => {
       providers: [ComponentTest],
     }).compile();
     const componentTest = module.get<ComponentTest>(ComponentTest);
-    expect(componentTest.testConfig(null)).toEqual({ port: 2000 });
+    expect(componentTest.testConfig()).toEqual({ port: 2000 });
   });
 
   it('Multiple ConfigParam decorators', async () => {
@@ -56,8 +56,8 @@ describe('Config Nest Module', () => {
 
       @Configurable()
       testConfig(
-        @ConfigParam('config.server') server: any,
-        @ConfigParam('config.stub') stub: any
+        @ConfigParam('config.server') server?: { port: 2000 },
+        @ConfigParam('config.stub') stub?: { port: 2000 }
       ) {
         return { serverPort: server.port, stubPort: stub.port };
       }
@@ -70,7 +70,7 @@ describe('Config Nest Module', () => {
       providers: [ComponentTest],
     }).compile();
     const componentTest = module.get<ComponentTest>(ComponentTest);
-    expect(componentTest.testConfig(null, null)).toEqual({ serverPort: 2000, stubPort: 2000 });
+    expect(componentTest.testConfig()).toEqual({ serverPort: 2000, stubPort: 2000 });
   });
   it('ConfigParam decorators in a static factory method with injected service', async () => {
     class ComponentTest {
@@ -160,7 +160,7 @@ describe('Config Nest Module', () => {
       @Configurable()
       testConfig(
         @ConfigParam('config.doesntexists', 'test123')
-        configKey: string,
+        configKey?: string,
       ) {
         return configKey;
       }
@@ -173,7 +173,7 @@ describe('Config Nest Module', () => {
       providers: [ComponentTest],
     }).compile();
     const componentTest = module.get<ComponentTest>(ComponentTest);
-    expect(componentTest.testConfig(null)).toEqual('test123');
+    expect(componentTest.testConfig()).toEqual('test123');
   });
   it('Will get the right `this` from class', async () => {
     @Injectable()
@@ -183,7 +183,7 @@ describe('Config Nest Module', () => {
         this.foo = 'bar';
       }
       @Configurable()
-      testConfig(@ConfigParam('config.server') configKey: string) {
+      testConfig(@ConfigParam('config.server') configKey?: { port: 2000 }) {
         let result = this.testConfig2('testConfig');
         expect(result).toBeTruthy();
         expect(this.foo).toEqual('bar');
@@ -201,7 +201,7 @@ describe('Config Nest Module', () => {
       providers: [ComponentTest],
     }).compile();
     const componentTest = module.get<ComponentTest>(ComponentTest);
-    expect(componentTest.testConfig(null)).toEqual({ port: 2000 });
+    expect(componentTest.testConfig()).toEqual({ port: 2000 });
   });
   it('Will get the right `this` from class and its parents', async () => {
     @Injectable()
@@ -221,7 +221,7 @@ describe('Config Nest Module', () => {
         super();
       }
       @Configurable()
-      testConfig(@ConfigParam('config.server') configKey: string) {
+      testConfig(@ConfigParam('config.server') configKey?: { port: 2000 }) {
         let result = this.testConfig2('testConfig');
         let resultFromParent = this.testConfig3('testConfig');
         expect(result).toBeTruthy();
@@ -241,6 +241,6 @@ describe('Config Nest Module', () => {
       providers: [ComponentTest],
     }).compile();
     const componentTest = module.get<ComponentTest>(ComponentTest);
-    expect(componentTest.testConfig(null)).toEqual({ port: 2000 });
+    expect(componentTest.testConfig()).toEqual({ port: 2000 });
   });
 });

--- a/src/__tests__/config.module.spec.ts
+++ b/src/__tests__/config.module.spec.ts
@@ -48,7 +48,46 @@ describe('Config Nest Module', () => {
     const componentTest = module.get<ComponentTest>(ComponentTest);
     expect(componentTest.testConfig()).toEqual({ port: 2000 });
   });
+  it('Configurable decorator should do nothing without ConfigParam decorator', async () => {
+    @Injectable()
+    class ComponentTest {
+      constructor() {}
 
+      @Configurable()
+      testConfig(server: { port: number }) {
+        return {serverPort: server.port};
+      }
+    }
+
+    const module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.load(path.resolve(__dirname, '__stubs__', '**/*.ts')),
+      ],
+      providers: [ComponentTest],
+    }).compile();
+    const componentTest = module.get<ComponentTest>(ComponentTest);
+    expect(componentTest.testConfig({port: 42})).toEqual({serverPort: 42});
+  });
+  it('ConfigParam decorator on null argument', async () => {
+    @Injectable()
+    class ComponentTest {
+      constructor() {}
+
+      @Configurable()
+      testConfig(@ConfigParam('config.server') server: null | { port: number },) {
+        return {serverPort: server.port };
+      }
+    }
+
+    const module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.load(path.resolve(__dirname, '__stubs__', '**/*.ts')),
+      ],
+      providers: [ComponentTest],
+    }).compile();
+    const componentTest = module.get<ComponentTest>(ComponentTest);
+    expect(componentTest.testConfig(null)).toEqual({serverPort: 2000});
+  });
   it('Multiple ConfigParam decorators', async () => {
     @Injectable()
     class ComponentTest {
@@ -56,8 +95,8 @@ describe('Config Nest Module', () => {
 
       @Configurable()
       testConfig(
-        @ConfigParam('config.server') server?: { port: 2000 },
-        @ConfigParam('config.stub') stub?: { port: 2000 }
+        @ConfigParam('config.server') server?: { port: number },
+        @ConfigParam('config.stub') stub?: { port: number }
       ) {
         return { serverPort: server.port, stubPort: stub.port };
       }
@@ -183,7 +222,7 @@ describe('Config Nest Module', () => {
         this.foo = 'bar';
       }
       @Configurable()
-      testConfig(@ConfigParam('config.server') configKey?: { port: 2000 }) {
+      testConfig(@ConfigParam('config.server') configKey?: { port: number }) {
         let result = this.testConfig2('testConfig');
         expect(result).toBeTruthy();
         expect(this.foo).toEqual('bar');
@@ -221,7 +260,7 @@ describe('Config Nest Module', () => {
         super();
       }
       @Configurable()
-      testConfig(@ConfigParam('config.server') configKey?: { port: 2000 }) {
+      testConfig(@ConfigParam('config.server') configKey?: { port: number }) {
         let result = this.testConfig2('testConfig');
         let resultFromParent = this.testConfig3('testConfig');
         expect(result).toBeTruthy();

--- a/src/decorators/ConfigParam.ts
+++ b/src/decorators/ConfigParam.ts
@@ -11,7 +11,7 @@ export const ConfigParam = (
   // Add this parameter
   existingParameters.push({ parameterIndex, propertyKey, configKey, fallback });
   // Update the required parameters for this method
-  Reflect.defineMetadata(CONFIG_PARAMS, existingParameters, target);
+  Reflect.defineMetadata(CONFIG_PARAMS, existingParameters, target, propertyKey);
   return target;
 };
 export default ConfigParam;

--- a/src/decorators/Configurable.ts
+++ b/src/decorators/Configurable.ts
@@ -12,7 +12,7 @@ export const Configurable = (): MethodDecorator => {
     const originalMethod = descriptor.value;
     descriptor.value = function(...args: any[]) {
       const paramsMetadata = (
-        Reflect.getMetadata(CONFIG_PARAMS, target) || []
+        Reflect.getMetadata(CONFIG_PARAMS, target, key) || []
       ).filter(p => {
         return p.propertyKey === key;
       });
@@ -24,7 +24,7 @@ export const Configurable = (): MethodDecorator => {
 
     Reflect.defineMetadata(
       CONFIG_CONFIGURABLE,
-      Reflect.getMetadata(CONFIG_PARAMS, target) || [],
+      Reflect.getMetadata(CONFIG_PARAMS, target, key) || [],
       descriptor.value,
     );
     return descriptor;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,20 +1,25 @@
+import { ConfigService } from "./module";
+
 export function applyParamsMetadataDecorator(
   paramsMetadata: any[],
   args: any[],
   fn: (key: string, def?: string) => string,
 ): any[] {
-  if (paramsMetadata.length && args.length) {
+  if (paramsMetadata.length) {
     // Override the original parameter value
     // with the expected property of the value even a deep property.
     for (const param of paramsMetadata) {
-      if (typeof args[param.parameterIndex] === 'object') {
-        if (!param.configKey) {
-          args[param.parameterIndex] = args[param.parameterIndex];
-          continue;
+      if (param.configKey) {
+        const i = param.parameterIndex;
+        if (args[i] instanceof ConfigService || args[i] === ConfigService) {
+          // if parameter is a ConfigService instance or ConfigService cass itself
+          // then retrieve required config param from this instance
+          args[param.parameterIndex] = args[i].get(param.configKey, param.fallback);
+        } else if (args[i] === undefined || args[i] === null) {
+          // if parameter is null or undefined
+          // then retrieve required config param from passed fn
+          args[param.parameterIndex] = fn(param.configKey, param.fallback);
         }
-        // get the value from config here !
-        // a better way ?
-        args[param.parameterIndex] = fn(param.configKey, param.fallback);
       }
     }
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,15 +9,22 @@ export function applyParamsMetadataDecorator(
     // Override the original parameter value
     // with the expected property of the value even a deep property.
     for (const param of paramsMetadata) {
-      if (param.configKey) {
+      if (Object.keys(param).includes('configKey')) {
         const i = param.parameterIndex;
         if (args[i] instanceof ConfigService || args[i] === ConfigService) {
           // if parameter is a ConfigService instance or ConfigService cass itself
           // then retrieve required config param from this instance
           args[param.parameterIndex] = args[i].get(param.configKey, param.fallback);
-        } else if (args[i] === undefined || args[i] === null) {
-          // if parameter is null or undefined
-          // then retrieve required config param from passed fn
+        } else if (args[i] === undefined) {
+          // populate undefined argument with the config parameter value
+          args[param.parameterIndex] = fn(param.configKey, param.fallback);
+        } else if (args[i] === null) {
+          /**
+           * nestjs router populates missing parameters with nulls by default
+           * so we need to populate nullable argument with the config parameter value too.
+           * @link https://github.com/nestjs/nest/blob/master/packages/core/router/router-execution-context.ts#L117
+           * @link https://github.com/nestjs/nest/issues/1182
+           */
           args[param.parameterIndex] = fn(param.configKey, param.fallback);
         }
       }


### PR DESCRIPTION
This PR fixes 2 bugs in `ConfigParam()` and `Configurable()` decorator

1. `ConfigParam()` decorator set metadata to the target: `Reflect.defineMetadata(CONFIG_PARAMS, existingParameters, target)`, but always retrieved it from target's property: `Reflect.getMetadata(CONFIG_PARAMS, target, propertyKey)`. So previous metadata was deleted if decorator was called 2 times or more on the same method.

2. Utility `applyParamsMetadataDecorator()` set config param to the argument only if the argument exists and it's an object (some unsafe condition as for me). So `ConfigParam()` decorator worked only the `ConfigService()` was injected on the argument's place.

But it's a  fact that ConfigService may be not injected in all required places (check additional tests).
So I also added improvements to the `applyParamsMetadataDecorator()` utility.


P.S. Probably it is't a question to the `nestjs-config` and not a topic of this PR, but when `Configurable()` decorator applied to the controller method and it was placed to top of order - it breaks other decorators.
```typescript
  @Configurable()
  @Get('cats')
  @UseInterceptors(MyInterceptor)
  public getMostLikedPosts(@ConfigParam('key') key):  {
    return [];
  }
```

I think it's because it replaces original method with own function.
It will be nice to have some note in the Readme that `Configurable()` decorator must be the last.