### PR TITLE
Fix tsconfig for 2nd and next builds

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,6 +23,7 @@
   ],
   "exclude": [
     "./index.ts",
+    "./index.d.ts",
     "node_modules",
     "./**/*.spec.ts",
     "examples"


### PR DESCRIPTION
[PR-35](https://github.com/nestjs-community/nestjs-config/pull/35) had updates for the tsconfig.json and build command.
After these update `npm run build` but... only 1st time. On the 2nd and next times, the build command fails because generated `index.d.ts` in the root of project.