### PR TITLE
Improve Configurable decorator due to resolving nestjs issue #1182

### DIFF
--- a/src/__tests__/config.module.spec.ts
+++ b/src/__tests__/config.module.spec.ts
@@ -75,7 +75,7 @@ describe('Config Nest Module', () => {
 
       @Configurable()
       testConfig(
-        @ConfigParam('config.server') server: null | { port: number },
+        @ConfigParam('config.server') server?: { port: number },
       ) {
         return { serverPort: server.port };
       }
@@ -88,7 +88,7 @@ describe('Config Nest Module', () => {
       providers: [ComponentTest],
     }).compile();
     const componentTest = module.get<ComponentTest>(ComponentTest);
-    expect(componentTest.testConfig(null)).toEqual({ serverPort: 2000 });
+    expect(componentTest.testConfig()).toEqual({ serverPort: 2000 });
   });
   it('Multiple ConfigParam decorators', async () => {
     @Injectable()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,14 +18,6 @@ export function applyParamsMetadataDecorator(
         } else if (args[i] === undefined) {
           // populate undefined argument with the config parameter value
           args[param.parameterIndex] = fn(param.configKey, param.fallback);
-        } else if (args[i] === null) {
-          /**
-           * nestjs router populates missing parameters with nulls by default
-           * so we need to populate nullable argument with the config parameter value too.
-           * @link https://github.com/nestjs/nest/blob/master/packages/core/router/router-execution-context.ts#L117
-           * @link https://github.com/nestjs/nest/issues/1182
-           */
-          args[param.parameterIndex] = fn(param.configKey, param.fallback);
         }
       }
     }


### PR DESCRIPTION
Basically nestjs had a bug with the default values during arguments initialization. 
Description exists in the created issue - https://github.com/nestjs/nest/issues/1182

The default arguments values were `null` instead of `undefined`, so in `Configurable()` decorator was additional checking for `null` value.

Bug is already fixed, so appropriate fix is needed for Configurable() decorator