### PR TITLE
Better config location

### DIFF
--- a/src/__tests__/config.module.spec.ts
+++ b/src/__tests__/config.module.spec.ts
@@ -5,7 +5,7 @@ import { Injectable } from '@nestjs/common';
 import { ConfigParam, Configurable } from '../decorators';
 
 describe('Config Nest Module', () => {
-  it('Will boot nest-config modoule succesfully', async () => {
+  it('Will boot nest-config module succesfully', async () => {
     const module = await Test.createTestingModule({
       imports: [
         ConfigModule.load(path.resolve(__dirname, '__stubs__', '**/*.ts')),
@@ -26,6 +26,19 @@ describe('Config Nest Module', () => {
     const configService = module.get<ConfigService>(ConfigService);
 
     expect(configService).toBeInstanceOf(ConfigService);
+  });
+
+  it('Will resolve application sources path', async() => {
+    const spy = jest.spyOn(ConfigService, 'resolveAppSrcPath');
+
+    await Test.createTestingModule({
+      imports: [ConfigModule.resolveAppSrcPath(__dirname).load()],
+    }).compile();
+
+    const expectedAppSrcPath = path.resolve(process.cwd(), 'src');
+
+    expect(spy).toHaveBeenCalled();
+    expect(ConfigService.appSrcPath).toEqual(expectedAppSrcPath);
   });
 
   it('Will Setup Modules with its Components', async () => {

--- a/src/__tests__/config.module.spec.ts
+++ b/src/__tests__/config.module.spec.ts
@@ -29,16 +29,16 @@ describe('Config Nest Module', () => {
   });
 
   it('Will resolve application sources path', async() => {
-    const spy = jest.spyOn(ConfigService, 'resolveAppSrcPath');
+    const spy = jest.spyOn(ConfigService, 'resolveSrcPath');
 
     await Test.createTestingModule({
-      imports: [ConfigModule.resolveAppSrcPath(__dirname).load()],
+      imports: [ConfigModule.resolveSrcPath(__dirname).load()],
     }).compile();
 
     const expectedAppSrcPath = path.resolve(process.cwd(), 'src');
 
     expect(spy).toHaveBeenCalled();
-    expect(ConfigService.appSrcPath).toEqual(expectedAppSrcPath);
+    expect(ConfigService.srcPath).toEqual(expectedAppSrcPath);
   });
 
   it('Will Setup Modules with its Components', async () => {

--- a/src/__tests__/config.service.spec.ts
+++ b/src/__tests__/config.service.spec.ts
@@ -95,7 +95,7 @@ describe('Config Service', () => {
       process.cwd = realProcessCwd;
     });
 
-    it('Will return a src directory', () => {
+    it('Will return a src directory for relative path', () => {
       const realProcessCwd = process.cwd;
 
       const mockedCwdPath = __dirname;
@@ -105,6 +105,11 @@ describe('Config Service', () => {
       expect(ConfigService.src('config')).toEqual(expectedPath);
 
       process.cwd = realProcessCwd;
+    });
+
+    it('Will return a src directory for absolute path', () => {
+      const expectedPath = '/tmp/config';
+      expect(ConfigService.src('/tmp/config')).toEqual(expectedPath);
     });
   });
 });

--- a/src/__tests__/config.service.spec.ts
+++ b/src/__tests__/config.service.spec.ts
@@ -91,12 +91,12 @@ describe('Config Service', () => {
       realProcessCwd = process.cwd;
       process.cwd = () => __dirname;
 
-      currentAppRoot = ConfigService.appSrcPath;
-      ConfigService.appSrcPath = undefined;
+      currentAppRoot = ConfigService.srcPath;
+      ConfigService.srcPath = undefined;
     });
 
     afterEach(() => {
-      ConfigService.appSrcPath = currentAppRoot;
+      ConfigService.srcPath = currentAppRoot;
       process.cwd = realProcessCwd;
     });
 
@@ -113,8 +113,8 @@ describe('Config Service', () => {
       const expectedAppRoot = path.join(__dirname, 'dist');
       const currentFilePath = path.join(__dirname, 'dist', 'app', 'app.module.js');
 
-      ConfigService.resolveAppSrcPath(currentFilePath);
-      expect(ConfigService.appSrcPath).toEqual(expectedAppRoot);
+      ConfigService.resolveSrcPath(currentFilePath);
+      expect(ConfigService.srcPath).toEqual(expectedAppRoot);
     });
 
     it('Will resolve application src path only once', () => {
@@ -122,14 +122,14 @@ describe('Config Service', () => {
       const firstStartPath = path.join(__dirname, 'src', 'app', 'app.module.js');
       const secondStartPath = path.join(__dirname, 'dist', 'app', 'app.module.js');
 
-      ConfigService.resolveAppSrcPath(firstStartPath);
-      ConfigService.resolveAppSrcPath(secondStartPath);
-      expect(ConfigService.appSrcPath).toEqual(expectedAppRoot);
+      ConfigService.resolveSrcPath(firstStartPath);
+      ConfigService.resolveSrcPath(secondStartPath);
+      expect(ConfigService.srcPath).toEqual(expectedAppRoot);
     });
 
     it('Will throw error if start path for app src resolution is not an absolute path', (done) => {
       try {
-        ConfigService.resolveAppSrcPath('some/relative/path');
+        ConfigService.resolveSrcPath('some/relative/path');
       } catch (e) {
         done();
       }
@@ -143,7 +143,7 @@ describe('Config Service', () => {
       const appSrcRoot = path.join(__dirname, 'dist');
       const startPath = path.join(appSrcRoot, 'app', 'app.module.js');
 
-      ConfigService.resolveAppSrcPath(startPath);
+      ConfigService.resolveSrcPath(startPath);
       expect(ConfigService.src()).toEqual(appSrcRoot);
     });
 
@@ -152,7 +152,7 @@ describe('Config Service', () => {
       const startPath = path.join(appSrcRoot, 'app', 'app.module.js');
       const expectedPath = path.join(appSrcRoot, 'config');
 
-      ConfigService.resolveAppSrcPath(startPath);
+      ConfigService.resolveSrcPath(startPath);
       expect(ConfigService.src('config')).toEqual(expectedPath);
     });
 

--- a/src/module/config.module.ts
+++ b/src/module/config.module.ts
@@ -6,6 +6,12 @@ import { DotenvOptions } from 'dotenv';
 @Global()
 @Module({})
 export class ConfigModule {
+
+  static resolveAppSrcPath(startPath: string): typeof ConfigModule {
+    ConfigService.resolveAppSrcPath(startPath);
+    return this;
+  }
+
   /**
    * From Glob
    * @param glob

--- a/src/module/config.module.ts
+++ b/src/module/config.module.ts
@@ -7,8 +7,8 @@ import { DotenvOptions } from 'dotenv';
 @Module({})
 export class ConfigModule {
 
-  static resolveAppSrcPath(startPath: string): typeof ConfigModule {
-    ConfigService.resolveAppSrcPath(startPath);
+  static resolveSrcPath(startPath: string): typeof ConfigModule {
+    ConfigService.resolveSrcPath(startPath);
     return this;
   }
 

--- a/src/module/config.service.ts
+++ b/src/module/config.service.ts
@@ -29,7 +29,7 @@ export class ConfigService {
   private readonly helpers: CustomHelper = {};
 
   protected static defaultGlob: string = 'src/config/**/*.{ts,js}';
-  static appSrcPath?: string;
+  static srcPath?: string;
 
   /**
    * @param {Config} config
@@ -165,7 +165,7 @@ export class ConfigService {
    * @returns {string}
    */
   static src(dir: string = ''): string {
-    const srcPath = this.appSrcPath || this.root();
+    const srcPath = this.srcPath || this.root();
     return path.resolve(srcPath, dir);
   }
 
@@ -174,10 +174,10 @@ export class ConfigService {
    * @param {string} startPath
    *  The path for search starting. Can be any path under app sources path.
    */
-  static resolveAppSrcPath(startPath: string): typeof ConfigService {
+  static resolveSrcPath(startPath: string): typeof ConfigService {
     ok(path.isAbsolute(startPath), 'Start path must be an absolute path.');
 
-    if (!this.appSrcPath) {
+    if (!this.srcPath) {
       const root = this.root();
 
       let src = startPath;
@@ -188,7 +188,7 @@ export class ConfigService {
         parent = path.dirname(src);
       }
 
-      this.appSrcPath = src;
+      this.srcPath = src;
     }
 
     return this;

--- a/src/module/config.service.ts
+++ b/src/module/config.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@nestjs/common';
+import * as assert from 'assert';
 import * as get from 'lodash.get';
 import * as set from 'lodash.set';
 import * as dotenv from 'dotenv';
-import * as path from 'path';
-import { ok } from 'assert';
-import { Glob, sync as globSync } from 'glob';
 import { DotenvOptions } from 'dotenv';
+import * as path from 'path';
+import { Glob, sync as globSync } from 'glob';
 import { ProxyProperty } from '../decorators/proxy';
 
 export interface ModuleConfig {
@@ -175,7 +175,7 @@ export class ConfigService {
    *  The path for search starting. Can be any path under app sources path.
    */
   static resolveSrcPath(startPath: string): typeof ConfigService {
-    ok(path.isAbsolute(startPath), 'Start path must be an absolute path.');
+    assert.ok(path.isAbsolute(startPath), 'Start path must be an absolute path.');
 
     if (!this.srcPath) {
       const root = this.root();


### PR DESCRIPTION
This PR add 3 improvements to the config service:

1) `getConfigName()` was refactored for the ability to use any files with config (e.g. *.json). Hardcoded `.ts` and `.js` were replaced with `path` module functionality.

2) An ability to use globs with relative paths was added - `src()` method was refactored with `path` functionality instead string concatenation. Now `src()` method is called always for glob parameters.

3) Was added `resolveSrcPath()` which allows to resolve application sources root. 
I think that this is a good feature, because application sources root is changed from `src` to `dist` after typescript compilation. Also tests were updated and an example was added to the Readme.
This update isn't the best possible solution and may be not so required, but it's the simplest solution which is possible with current module architecture. Also an existing behavior was kept, so there is no breaking changes.


This PR can be separated for 3 different PRs if it is required.