### PR TITLE
Provide optional modify config name function

### DIFF
--- a/examples/decorators/user.controller.ts
+++ b/examples/decorators/user.controller.ts
@@ -6,8 +6,7 @@ export default class UserController {
   @Get('')
   @Configurable()
   index(
-    @ConfigParam('user.name', 'test')
-    username,
+    @ConfigParam('user.name', 'test') username,
     @ConfigParam('app.development') live,
   ): object {
     return {

--- a/src/__tests__/config.module.spec.ts
+++ b/src/__tests__/config.module.spec.ts
@@ -222,8 +222,7 @@ describe('Config Nest Module', () => {
 
       @Configurable()
       testConfig(
-        @ConfigParam('config.doesntexists', 'test123')
-        configKey?: string,
+        @ConfigParam('config.doesntexists', 'test123') configKey?: string,
       ) {
         return configKey;
       }
@@ -305,19 +304,19 @@ describe('Config Nest Module', () => {
   });
 
   it('Will allow to override config name key', async () => {
-      const module = await Test.createTestingModule({
-          imports: [
-              ConfigModule.load(path.resolve(__dirname, '__stubs__', '**/*.ts'), {
-                modifyConfigName: (name) => name.replace('config.', ''),
-              }),
-          ],
-      }).compile();
+    const module = await Test.createTestingModule({
+      imports: [
+        ConfigModule.load(path.resolve(__dirname, '__stubs__', '**/*.ts'), {
+          modifyConfigName: name => name.replace('config.', ''),
+        }),
+      ],
+    }).compile();
 
-      const configService = module.get<ConfigService>(ConfigService);
+    const configService = module.get<ConfigService>(ConfigService);
 
-      expect(configService.get('config.server')).toBeUndefined();
-      expect(configService.get('config.stub')).toBeUndefined();
-      expect(configService.get('server')).toBeTruthy();
-      expect(configService.get('stub')).toBeTruthy();
+    expect(configService.get('config.server')).toBeUndefined();
+    expect(configService.get('config.stub')).toBeUndefined();
+    expect(configService.get('server')).toBeTruthy();
+    expect(configService.get('stub')).toBeTruthy();
   });
 });

--- a/src/__tests__/config.module.spec.ts
+++ b/src/__tests__/config.module.spec.ts
@@ -303,4 +303,21 @@ describe('Config Nest Module', () => {
     const componentTest = module.get<ComponentTest>(ComponentTest);
     expect(componentTest.testConfig()).toEqual({ port: 2000 });
   });
+
+  it('Will allow to override config name key', async () => {
+      const module = await Test.createTestingModule({
+          imports: [
+              ConfigModule.load(path.resolve(__dirname, '__stubs__', '**/*.ts'), {
+                modifyConfigName: (name) => name.replace('config.', ''),
+              }),
+          ],
+      }).compile();
+
+      const configService = module.get<ConfigService>(ConfigService);
+
+      expect(configService.get('config.server')).toBeUndefined();
+      expect(configService.get('config.stub')).toBeUndefined();
+      expect(configService.get('server')).toBeTruthy();
+      expect(configService.get('stub')).toBeTruthy();
+  });
 });

--- a/src/module/config.module.ts
+++ b/src/module/config.module.ts
@@ -1,6 +1,6 @@
 import 'reflect-metadata';
 import { DynamicModule, Module, Global } from '@nestjs/common';
-import {ConfigService, Options} from './config.service';
+import { ConfigService, ConfigOptions } from './config.service';
 
 @Global()
 @Module({})
@@ -13,10 +13,10 @@ export class ConfigModule {
   /**
    * From Glob
    * @param glob
-   * @param {Options} options
+   * @param {ConfigOptions} options
    * @returns {DynamicModule}
    */
-  static load(glob?: string, options?: Options): DynamicModule {
+  static load(glob?: string, options?: ConfigOptions): DynamicModule {
     const configProvider = {
       provide: ConfigService,
       useFactory: async (): Promise<ConfigService> => {

--- a/src/module/config.module.ts
+++ b/src/module/config.module.ts
@@ -1,7 +1,6 @@
 import 'reflect-metadata';
 import { DynamicModule, Module, Global } from '@nestjs/common';
-import { ConfigService } from './config.service';
-import { DotenvOptions } from 'dotenv';
+import {ConfigService, Options} from './config.service';
 
 @Global()
 @Module({})
@@ -14,10 +13,10 @@ export class ConfigModule {
   /**
    * From Glob
    * @param glob
-   * @param {DotenvOptions} options
+   * @param {Options} options
    * @returns {DynamicModule}
    */
-  static load(glob?: string, options?: DotenvOptions): DynamicModule {
+  static load(glob?: string, options?: Options): DynamicModule {
     const configProvider = {
       provide: ConfigService,
       useFactory: async (): Promise<ConfigService> => {

--- a/src/module/config.service.ts
+++ b/src/module/config.service.ts
@@ -22,7 +22,7 @@ export type CustomHelper = {
 
 
 export interface ConfigOptions {
-  modifyConfigName: (name: string) => string
+  modifyConfigName?: (name: string) => string
 }
 
 export type Options = DotenvOptions & ConfigOptions;


### PR DESCRIPTION
I found my self having config files named with the following convention `{moduleName}.config.ts` 

although i really don't like accessing the configs in this way
```config.get(['items.config', 'someconfigKey'])```

 I still want to be able to access my config in the following way 
```config.get('items.someconfigKey')```

This PR allows to pass an optional function that can alter or modify the original top level config name.