### PR TITLE
[WIP] Refactored src methods to use root keyword instead but keeping backwards compatibility 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ import { Module } from '@nestjs/common';
 import { BootstrapModule } from './bootstrap';
 import { ConfigService } from 'nestjs-config';
 
-ConfigService.srcPath = path.resolve(__dirname, '..');
+ConfigService.rootPath = path.resolve(__dirname, '..');
 
 @Module({
     imports: [BootstrapModule],
@@ -121,9 +121,9 @@ import { ConfigModule } from 'nestjs-config';
 })
 export class BootstrapModule {}
 ```
-Setting the `ConfigService.srcPath` before calling `ConfigModule.load(...)` will change the default root dir of where your configs are loaded from.
+Setting the `ConfigService.rootPath` before calling `ConfigModule.load(...)` will change the default root dir of where your configs are loaded from.
 
-Another method is to invoke `ConfigModule.resolveSrcPath(__dirname)` from any module before loading the config and use glob with a relative path.
+Another method is to invoke `ConfigModule.resolveRootPath(__dirname)` from any module before loading the config and use glob with a relative path.
   ```ts
   // bootstrap.module.ts
   import { Module } from '@nestjs/common';
@@ -131,7 +131,7 @@ Another method is to invoke `ConfigModule.resolveSrcPath(__dirname)` from any mo
   
   @Module({
       imports: [
-        ConfigModule.resolveSrcPath(__dirname).load('config/**/!(*.d).{ts,js}')
+        ConfigModule.resolveRootPath(__dirname).load('config/**/!(*.d).{ts,js}')
       ],
   })
   export class BootstrapModule {}
@@ -441,7 +441,7 @@ this.config.registerHelper('isProduction', () => {
 });
 ```
 
-#### resolveSrcPath(path: string): typeof ConfigService
+#### resolveRootPath(path: string): typeof ConfigService
 change the root path from where configs files are loaded
 
 ```ts
@@ -450,7 +450,7 @@ import { ConfigModule } from 'nestjs-config';
 
 @Module({
     imports: [
-        ConfigModule.resolveSrcPath(__dirname).load(path.resolve(__dirname, '**/!(*.d).{ts,js}')),
+        ConfigModule.resolveRootPath(__dirname).load(path.resolve(__dirname, '**/!(*.d).{ts,js}')),
     ],
 })
 export class AppModule {}
@@ -458,3 +458,14 @@ export class AppModule {}
 -----
 
 Built by Fenos, Shekohex and Bashleigh
+
+#### root(path: string = ''): string
+
+Returns the current working dir or defined rootPath. 
+
+```ts
+ConfigService.root(); // /var/www/src
+ConfigService.root('some/path/file.html'); // /var/www/src/some/path/file.html
+
+ConfigService.resolveRootPath(__dirname).root(); // /var/www/src/app (or wherever resolveRootPath has been called with)
+```

--- a/src/__tests__/config.service.spec.ts
+++ b/src/__tests__/config.service.spec.ts
@@ -123,6 +123,9 @@ describe('Config Service', () => {
     });
 
     it('Will resolve application src path only once', () => {
+      ConfigService.rootPath = undefined;
+      ConfigService.srcPath = undefined;
+      
       const expectedAppRoot = path.join(__dirname, 'src');
       const firstStartPath = path.join(
         __dirname,
@@ -139,7 +142,7 @@ describe('Config Service', () => {
 
       ConfigService.resolveSrcPath(firstStartPath);
       ConfigService.resolveSrcPath(secondStartPath);
-      expect(ConfigService.srcPath).toEqual(expectedAppRoot);
+      expect(ConfigService.rootPath).toEqual(expectedAppRoot);
     });
 
     it('Will throw error if start path for app src resolution is not an absolute path', done => {
@@ -151,6 +154,8 @@ describe('Config Service', () => {
     });
 
     it('Will return a src path equal to process root by default', () => {
+      ConfigService.srcPath = undefined;
+      ConfigService.rootPath = undefined;
       expect(ConfigService.src()).toEqual(__dirname);
     });
 

--- a/src/__tests__/config.service.spec.ts
+++ b/src/__tests__/config.service.spec.ts
@@ -93,10 +93,12 @@ describe('Config Service', () => {
 
       currentAppRoot = ConfigService.srcPath;
       ConfigService.srcPath = undefined;
+      ConfigService.rootPath = undefined;
     });
 
     afterEach(() => {
-      ConfigService.srcPath = currentAppRoot;
+      ConfigService.srcPath = undefined;
+      ConfigService.rootPath = undefined;
       process.cwd = realProcessCwd;
     });
 
@@ -123,9 +125,6 @@ describe('Config Service', () => {
     });
 
     it('Will resolve application src path only once', () => {
-      ConfigService.rootPath = undefined;
-      ConfigService.srcPath = undefined;
-      
       const expectedAppRoot = path.join(__dirname, 'src');
       const firstStartPath = path.join(
         __dirname,
@@ -154,8 +153,6 @@ describe('Config Service', () => {
     });
 
     it('Will return a src path equal to process root by default', () => {
-      ConfigService.srcPath = undefined;
-      ConfigService.rootPath = undefined;
       expect(ConfigService.src()).toEqual(__dirname);
     });
 
@@ -179,6 +176,23 @@ describe('Config Service', () => {
     it('Will return a src directory for absolute path', () => {
       const expectedPath = '/tmp/config';
       expect(ConfigService.src('/tmp/config')).toEqual(expectedPath);
+    });
+
+    it('Will resolve root with param', () => {
+      expect(ConfigService.root('config')).toEqual(path.join(__dirname, 'config'));
+    });
+
+    it('Will resolve root', () => {
+      expect(ConfigService.root()).toEqual(path.join(__dirname));
+    });
+
+    it('Will return path, reolated to resolved app root path', () => {
+      const root = path.join(__dirname, 'dist');
+      const startPath = path.join(root, 'app', 'app.module.js');
+      const expectedPath = path.join(root, 'config');
+
+      ConfigService.resolveRootPath(startPath);
+      expect(ConfigService.root('config')).toEqual(expectedPath);
     });
   });
 });

--- a/src/module/config.service.ts
+++ b/src/module/config.service.ts
@@ -176,6 +176,10 @@ export class ConfigService {
    * @deprecated use configService.root() instead
    */
   public static src(dir: string = ''): string {
+    console.log(
+      `\x1b[33m%s\x1b[0m`,
+      `WARNING: Method 'src' has been deprecated. Please use 'root'`,
+    );
     return this.root(dir);
   }
 
@@ -214,6 +218,10 @@ export class ConfigService {
    * @deprecated use configService.resolveRootPath() instead
    */
   public static resolveSrcPath(startPath: string): typeof ConfigService {
+    console.log(
+      `\x1b[33m%s\x1b[0m`,
+      `WARNING: Method 'resolveSrcPath' has been deprecated. Please use 'resolveRootPath'`,
+    );
     return this.resolveRootPath(startPath);
   }
 

--- a/src/module/config.service.ts
+++ b/src/module/config.service.ts
@@ -226,7 +226,7 @@ export class ConfigService {
     glob: string,
     options?: ConfigOptions | false,
   ): Promise<Config> {
-    glob = this.src(glob);
+    glob = this.root(glob);
     return new Promise((resolve, reject) => {
       new Glob(glob, {}, (err, matches) => {
         /* istanbul ignore if */
@@ -256,7 +256,7 @@ export class ConfigService {
     glob: string,
     options?: ConfigOptions | false,
   ): Config {
-    glob = this.src(glob);
+    glob = this.root(glob);
     const matches = globSync(glob);
     this.loadEnv(options);
 


### PR DESCRIPTION
So I mentioned in #53 and #61 that I thought the `src()`, `resolveSrcPath()` methods and the `srcPath` property was a bit confusing/misleading as the methods didn't actually resolve src. The path could change depending on `process.cwd` or absolute path that was entered to resolveSrcPath with again is misleading as the src path is not changing? 

So I decided to rename these methods and property to `root()` `resolveRootPath()` and `rootPath` respectively. I've also kept the original methods and property in working order for backwards compatibility to be removed in a later version.

**Breaking changes**
This PR however would introduce breaking changing if deprecated methods were to be removed. I suggest we announce that they will be permanently removed in say version `1.4.0`?

